### PR TITLE
Ensure `results` is always an array

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -586,7 +586,7 @@ Node.prototype.getHistory = function (range)
 	var self = this;
 
 	var history = [];
-	var interv = {};
+	var interv = [];
 
 	console.time('=H=', 'his', 'Got history in');
 
@@ -607,7 +607,7 @@ Node.prototype.getHistory = function (range)
 		if (err) {
 			console.error('his', 'history fetch failed:', err);
 
-			results = false;
+			results = [];
 		}
 		else
 		{


### PR DESCRIPTION
See https://github.com/cubedro/eth-net-intelligence-api/pull/242